### PR TITLE
Reduce duplicate lines using yaml anchors

### DIFF
--- a/chesswar/docker-compose-dev.yaml
+++ b/chesswar/docker-compose-dev.yaml
@@ -4,7 +4,7 @@ services:
   api:
     container_name: chesswar-dev-api
     build:
-      context: /projects/chesswar/dev/repo
+      context: &repo_path /projects/chesswar/dev/repo
       dockerfile: Dockerfile-api
     restart: unless-stopped
 
@@ -21,7 +21,7 @@ services:
   web:
     container_name: chesswar-dev-web
     build:
-      context: /projects/chesswar/dev/repo
+      context: *repo_path
       dockerfile: Dockerfile-web
     restart: unless-stopped
 

--- a/chesswar/docker-compose-prod.yaml
+++ b/chesswar/docker-compose-prod.yaml
@@ -4,7 +4,7 @@ services:
   api:
     container_name: chesswar-prod-api
     build:
-      context: /projects/chesswar/prod/repo
+      context: &repo_path /projects/chesswar/prod/repo
       dockerfile: Dockerfile-api
     restart: unless-stopped
 
@@ -21,7 +21,7 @@ services:
   web:
     container_name: chesswar-prod-web
     build:
-      context: /projects/chesswar/prod/repo
+      context: *repo_path
       dockerfile: Dockerfile-web
     restart: unless-stopped
 


### PR DESCRIPTION
you can use YAML anchors to reduce duplicate data and to make changes to paths only require one update